### PR TITLE
q42020-update: Bump GraphQL library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ apply plugin: 'checkstyle'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 group = 'org.hypergraphql'
-version = '1.1.0'
+version = '2.0.0'
 
 sourceCompatibility = 11
 targetCompatibility = 11


### PR DESCRIPTION
Bump GraphQL library version to 15.0 and fix changes to GraphQLType. 
Bump library version to 2.0.0 to reflect breaking changes